### PR TITLE
Fix bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,8 @@ createApp().use(VueShepherdPlugin).mount('#app');
       }
     },
 
-    created(){
-      this.createTour();
-    },
-
     mounted(){
+      this.createTour();
       this.tour.start();
     }
   });


### PR DESCRIPTION
Per https://vuejs.org/guide/essentials/template-refs.html#accessing-the-refs, "you can only access the ref after the component is mounted". Therefore `this.createTour()` which uses `this.$ref.el` should be called in `mounted()` instead of `created()`